### PR TITLE
Fix MP process alive/exitcode inconsistency

### DIFF
--- a/src/integrationtest/python/_mp_manager_server.py
+++ b/src/integrationtest/python/_mp_manager_server.py
@@ -1,5 +1,5 @@
 #   -*- coding: utf-8 -*-
-#   Copyright 2019 Karellen, Inc. and contributors
+#   Copyright 2022 Karellen, Inc. and contributors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -27,9 +27,9 @@ from multiprocessing.util import get_logger
 
 from geventmp.monkey import GEVENT_SAVED_MODULE_SETTINGS
 
-REQUEST_COUNT = 10
-QUEUE_SIZE = 3
-QUEUE_DEPTH = 10
+REQUEST_COUNT = 100
+QUEUE_SIZE = 5
+QUEUE_DEPTH = 100
 
 
 def idle_watcher():
@@ -127,7 +127,7 @@ def _manager_process(addr):
                 for i in range(0, REQUEST_COUNT):
                     spawn(process_conn, listener.accept(), i)
 
-                wait(timeout=60)
+                wait(timeout=300)
                 # logger.warning("\n".join(format_run_info()))
             finally:
                 manager.shutdown()

--- a/src/integrationtest/python/_mp_test_gevent.py
+++ b/src/integrationtest/python/_mp_test_gevent.py
@@ -16,12 +16,19 @@
 import sys
 from time import sleep
 
-from gevent import spawn
+from gevent import spawn, monkey
 from gevent.util import assert_switches
+from geventmp.monkey import GEVENT_SAVED_MODULE_SETTINGS
+from multiprocessing.util import get_logger
+
+logger = get_logger()
 
 
 def test_no_args():
-    print(test_no_args.__name__)
+    if not monkey.saved[GEVENT_SAVED_MODULE_SETTINGS].get("geventmp"):
+        raise RuntimeError("GeventMP patch has not run!")
+
+    logger.info(test_no_args.__name__)
 
     def count():
         while True:
@@ -35,6 +42,7 @@ def test_no_args():
 
     task.kill()
 
+    logger.info("exiting")
     sys.exit(10)
 
 
@@ -50,7 +58,7 @@ def test_queues(r_q, w_q):
         sleep(1)
 
     with assert_switches():
-        print(r_q.get(timeout=5))
+        logger.info(r_q.get(timeout=5))
 
     with assert_switches():
         sleep(1)
@@ -62,4 +70,5 @@ def test_queues(r_q, w_q):
         sleep(1)
 
     task.kill()
+    logger.info("exiting")
     sys.exit(10)

--- a/src/main/python/geventmp/_mp/3/_mp_connection.py
+++ b/src/main/python/geventmp/_mp/3/_mp_connection.py
@@ -14,12 +14,15 @@
 #   limitations under the License.
 
 from io import BytesIO
-from multiprocessing.connection import reduce_connection, _ConnectionBase as __ConnectionBase, Connection as _Connection
+from multiprocessing.connection import (reduce_connection,
+                                        _ConnectionBase as __ConnectionBase,
+                                        Connection as _Connection)
 
 import multiprocessing.reduction
 from gevent.os import make_nonblocking, nb_read, nb_write
+from gevent.selectors import GeventSelector
 
-__implements__ = ["_ConnectionBase", "Connection"]
+__implements__ = ["_ConnectionBase", "Connection", "_WaitSelector"]
 __target__ = "multiprocessing.connection"
 
 
@@ -63,3 +66,4 @@ def dump(obj, file, protocol=None):
 
 # multiprocessing.reduction.dump = dump
 multiprocessing.reduction.register(Connection, reduce_connection)
+_WaitSelector = GeventSelector

--- a/src/main/python/geventmp/_mp/3/_mp_popen_spawn_posix.py
+++ b/src/main/python/geventmp/_mp/3/_mp_popen_spawn_posix.py
@@ -1,5 +1,5 @@
 #   -*- coding: utf-8 -*-
-#   Copyright 2019 Karellen, Inc. and contributors
+#   Copyright 2022 Karellen, Inc. and contributors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -13,26 +13,18 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import sys
-from time import sleep
+from gevent.os import make_nonblocking
+from multiprocessing.popen_spawn_posix import Popen as _Popen
 
-from multiprocessing.util import get_logger
-
-logger = get_logger()
-
-
-def test_no_args():
-    logger.info(test_no_args.__name__)
-    sleep(1)
-    logger.info("exiting")
-    sys.exit(10)
+__implements__ = ["Popen"]
+__target__ = "multiprocessing.popen_spawn_posix"
 
 
-def test_queues(r_q, w_q):
-    sleep(1)
-    logger.info(r_q.get(timeout=5))
-    sleep(1)
-    w_q.put(test_queues.__name__, timeout=5)
-    sleep(1)
-    logger.info("exiting")
-    sys.exit(10)
+class Popen(_Popen):
+    def _launch(self, process_obj):
+        self.sentinel = None
+        try:
+            super()._launch(process_obj)
+        finally:
+            if self.sentinel is not None:
+                make_nonblocking(self.sentinel)

--- a/src/main/python/geventmp/_mp/3/_mp_util.py
+++ b/src/main/python/geventmp/_mp/3/_mp_util.py
@@ -13,7 +13,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from gevent.hub import _get_hub_noargs as get_hub
+from gevent.os import _watch_child
 from gevent.threading import local
 from multiprocessing.util import spawnv_passfds as _spawnv_passfd, register_after_fork
 
@@ -22,7 +22,9 @@ __target__ = "multiprocessing.util"
 
 
 def spawnv_passfds(path, args, passfds):
-    return get_hub().threadpool.apply(_spawnv_passfd, (path, args, passfds))
+    cpid = _spawnv_passfd(path, args, passfds)
+    _watch_child(cpid)
+    return cpid
 
 
 class ForkAwareLocal(local):

--- a/src/main/python/geventmp/monkey.py
+++ b/src/main/python/geventmp/monkey.py
@@ -160,6 +160,8 @@ def _patch_mp(will_patch_all):
         _patch_module("_mp.3._mp_util", _patch_module=True, _package_prefix='geventmp.')
         _patch_module("_mp.3._mp_connection", _patch_module=True, _package_prefix='geventmp.')
         _patch_module("_mp.3._mp_synchronize", _patch_module=True, _package_prefix='geventmp.')
+        _patch_module("_mp.3._mp_popen_fork", _patch_module=True, _package_prefix='geventmp.')
+        _patch_module("_mp.3._mp_popen_spawn_posix", _patch_module=True, _package_prefix='geventmp.')
         _patch_module("_mp.3._mp_forkserver", _patch_module=True, _package_prefix='geventmp.')
         if sys.version_info >= (3, 8):
             # See https://bugs.python.org/issue36867


### PR DESCRIPTION
Fix MP process alive/exitcode inconsistency

Don't spawn in a thread pool to cut down on latency
`mp.conn.wait` and `Popen.sentinel` geventified
Patched `spawnv_passfds` adds children to watch list
Increase size of the manager test

fixes #8