### PR TITLE
Implement SemLock with eventfd where available (3.10+/Linux)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
           - '3.6'
           - 'pypy-3.7'
           - 'pypy-3.8'
+          # - 'pypy-3.9'
         with-venv:
           - 'true'
           - 'false'

--- a/.idea/geventmp.iml
+++ b/.idea/geventmp.iml
@@ -7,7 +7,7 @@
       <excludeFolder url="file://$MODULE_DIR$/.pybuilder" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 3.7 (geventmp)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">

--- a/src/integrationtest/python/_mp_test_gevent.py
+++ b/src/integrationtest/python/_mp_test_gevent.py
@@ -18,8 +18,9 @@ from time import sleep
 
 from gevent import spawn, monkey
 from gevent.util import assert_switches
-from geventmp.monkey import GEVENT_SAVED_MODULE_SETTINGS
 from multiprocessing.util import get_logger
+
+from geventmp.monkey import GEVENT_SAVED_MODULE_SETTINGS
 
 logger = get_logger()
 
@@ -59,6 +60,37 @@ def test_queues(r_q, w_q):
 
     with assert_switches():
         logger.info(r_q.get(timeout=5))
+
+    with assert_switches():
+        sleep(1)
+
+    with assert_switches():
+        w_q.put(test_queues.__name__, timeout=5)
+
+    with assert_switches():
+        sleep(1)
+
+    task.kill()
+    logger.info("exiting")
+    sys.exit(10)
+
+
+def test_joinable_queues(r_q, w_q):
+    def count():
+        while True:
+            sleep(0.01)
+
+    task = spawn(count)
+    task.start()
+
+    with assert_switches():
+        sleep(1)
+
+    with assert_switches():
+        logger.info(r_q.get(timeout=5))
+
+    with assert_switches():
+        r_q.task_done()
 
     with assert_switches():
         sleep(1)

--- a/src/integrationtest/python/monkey_syncronizer_tests.py
+++ b/src/integrationtest/python/monkey_syncronizer_tests.py
@@ -1,0 +1,143 @@
+#   -*- coding: utf-8 -*-
+#   Copyright 2022 Karellen, Inc. and contributors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from multiprocessing.process import current_process
+
+from gevent import monkey
+
+if not getattr(current_process(), "_inheriting", False):
+    monkey.patch_all()
+
+    # from multiprocessing.util import log_to_stderr
+    # log_to_stderr(1)
+
+from unittest import TestCase, main
+
+from geventmp.monkey import GEVENT_SAVED_MODULE_SETTINGS
+
+import multiprocessing as mp
+from multiprocessing.util import get_logger
+import sys
+from time import monotonic
+
+logger = get_logger()
+
+
+class TestSynchronizers(TestCase):
+    def setUp(self):
+        self.assertTrue(monkey.saved[GEVENT_SAVED_MODULE_SETTINGS].get("geventmp"),
+                        "GeventMP patch has not run!")
+        self.tearDown()
+
+    def tearDown(self):
+        sys.stdout.flush()
+        sys.stderr.flush()
+        logger.info("=====================")
+        sys.stdout.flush()
+
+    def test_semaphore_fork(self):
+        self._test_semaphore("fork")
+
+    def test_semaphore_spawn(self):
+        self._test_semaphore("spawn")
+
+    def test_semaphore_forkserver(self):
+        self._test_semaphore("forkserver")
+
+    def test_bounded_semaphore_fork(self):
+        self._test_bounded_semaphore("fork")
+
+    def test_bounded_semaphore_spawn(self):
+        self._test_bounded_semaphore("spawn")
+
+    def test_bounded_semaphore_forkserver(self):
+        self._test_bounded_semaphore("forkserver")
+
+    def _test_semaphore(self, ctx_name):
+        ctx = mp.get_context(ctx_name)
+        s = ctx.Semaphore()
+        self.assertEqual(s.get_value(), 1)
+        self.assertEqual(s._semlock._count(), 0)
+        repr(s)
+
+        s.release()
+        self.assertEqual(s.get_value(), 2)
+        self.assertEqual(s._semlock._count(), -1)
+        repr(s)
+
+        self.assertTrue(s.acquire())
+        self.assertEqual(s.get_value(), 1)
+        self.assertEqual(s._semlock._count(), 0)
+        repr(s)
+
+        self.assertTrue(s.acquire())
+        self.assertEqual(s.get_value(), 0)
+        self.assertEqual(s._semlock._count(), 1)
+        repr(s)
+
+        self.assertFalse(s.acquire(block=False))
+        self.assertEqual(s.get_value(), 0)
+        self.assertEqual(s._semlock._count(), 1)
+        repr(s)
+
+        start = monotonic()
+        self.assertFalse(s.acquire(timeout=1))
+        duration = monotonic() - start
+        self.assertGreater(duration, 1)
+        self.assertLess(duration, 3)
+        s.release()
+        self.assertEqual(s.get_value(), 1)
+        self.assertEqual(s._semlock._count(), 0)
+
+    def _test_bounded_semaphore(self, ctx_name):
+        ctx = mp.get_context(ctx_name)
+        s = ctx.BoundedSemaphore(2)
+        repr(s)
+
+        self.assertEqual(s.get_value(), 2)
+        self.assertEqual(s._semlock._count(), 0)
+
+        self.assertTrue(s.acquire())
+        self.assertEqual(s.get_value(), 1)
+        self.assertEqual(s._semlock._count(), 1)
+        repr(s)
+
+        self.assertTrue(s.acquire())
+        self.assertEqual(s.get_value(), 0)
+        self.assertEqual(s._semlock._count(), 2)
+        repr(s)
+
+        self.assertFalse(s.acquire(block=False))
+        self.assertEqual(s.get_value(), 0)
+        self.assertEqual(s._semlock._count(), 2)
+        repr(s)
+
+        start = monotonic()
+        self.assertFalse(s.acquire(timeout=1))
+        duration = monotonic() - start
+        self.assertGreater(duration, 1)
+        self.assertLess(duration, 3)
+        s.release()
+        self.assertEqual(s.get_value(), 1)
+        self.assertEqual(s._semlock._count(), 1)
+        s.release()
+        self.assertEqual(s.get_value(), 2)
+        self.assertEqual(s._semlock._count(), 0)
+        with self.assertRaises(ValueError):
+            s.release()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/main/python/geventmp/_mp/3/_mp_synchronize.py
+++ b/src/main/python/geventmp/_mp/3/_mp_synchronize.py
@@ -13,32 +13,151 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import os
+import sys
+from multiprocessing import context
+from multiprocessing import reduction
+from multiprocessing import util
 from multiprocessing.synchronize import SemLock as _SemLock, \
     Semaphore as _Semaphore, \
     BoundedSemaphore as _BoundedSemaphore, \
     Lock as _Lock, \
-    RLock as _RLock
+    RLock as _RLock, \
+    SEMAPHORE, SEM_VALUE_MAX
+from threading import get_ident
 
 from gevent.hub import _get_hub_noargs as get_hub
+from gevent.os import nb_read, nb_write, _read, ignored_errors
+from gevent.timeout import with_timeout, Timeout
 
 __implements__ = ["SemLock", "Semaphore", "BoundedSemaphore", "Lock", "RLock"]
 __target__ = "multiprocessing.synchronize"
 
+_BUF_ONE = (1).to_bytes(8, sys.byteorder, signed=False)
+_pid = os.getpid()
 
-class SemLock(_SemLock):
+
+class SemLockEventFd:
+    def __init__(self, kind, value, maxvalue, *, ctx=None):
+        self.kind = kind
+        self.maxvalue = maxvalue
+        self.fd = os.eventfd(value, os.EFD_CLOEXEC | os.EFD_NONBLOCK | os.EFD_SEMAPHORE)
+        util.debug(f"created semlock with fd {self.fd}")
+        self._reset()
+
+    def _reset(self):
+        self._fd_path = f"/proc/{_pid}/fdinfo/{self.fd}"
+        self._semlock = self
+        self.count = 0
+        self.tid = None
+
+    def __del__(self):
+        try:
+            os.close(self.fd)
+        except OSError:
+            pass
+
+    def acquire(self, block=True, timeout=None):
+        if self.kind != SEMAPHORE and self._is_mine():
+            self.count += 1
+            return True
+
+        if block:
+            if timeout is not None:
+                try:
+                    with_timeout(timeout, nb_read, self.fd, 8)
+                except Timeout:
+                    return False
+            else:
+                nb_read(self.fd, 8)
+        else:
+            try:
+                _read(self.fd, 8)
+            except OSError as e:
+                if e.errno not in ignored_errors:
+                    raise
+                return False
+
+        self.count += 1
+        self.tid = get_ident()
+        return True
+
+    def release(self):
+        if self.kind != SEMAPHORE:
+            if not self._is_mine():
+                raise AssertionError("attempt to release recursive lock not owned by thread")
+
+            if self.count > 1:
+                self.count -= 1
+                return
+        elif self.maxvalue != SEM_VALUE_MAX:
+            count = self._get_value()
+            if count >= self.maxvalue:
+                raise ValueError("semaphore or lock released too many times")
+
+        nb_write(self.fd, _BUF_ONE)
+        self.count -= 1
+
+    def _get_value(self):
+        with open(self._fd_path, "rb") as f:
+            for line in f:
+                if line.startswith(b"eventfd-count:"):
+                    return int(line[14:].strip())
+
+    def _count(self):
+        return self.count
+
+    def _is_mine(self):
+        return self.count > 0 and self.tid == get_ident()
+
+    def _is_zero(self):
+        return self._get_value() == 0
+
+    def __enter__(self):
+        return self.acquire()
+
+    def __exit__(self, *args):
+        self.release()
+
+    def __getstate__(self):
+        context.assert_spawning(self)
+        df = reduction.DupFd(self.fd)
+        return df, self.kind, self.maxvalue
+
+    def __setstate__(self, state):
+        df, kind, maxvalue = state
+        fd = df.detach()
+        util.debug(f'recreated blocker with fd {fd}')
+        self.kind = kind
+        self.maxvalue = maxvalue
+        self.fd = fd
+        self._reset()
+
+
+class SemLockSem(_SemLock):
     def _make_methods(self):
         self._acquire = self._semlock.acquire
         self._release = self._semlock.release
 
     def acquire(self, *args, **kwargs):
+        if self._semlock.kind != SEMAPHORE:
+            return self._acquire(*args, **kwargs)
         return get_hub().threadpool.apply(self._acquire, args, kwargs)
 
     def release(self, *args, **kwargs):
         self._release(*args, **kwargs)
 
     def __enter__(self):
+        if self._semlock.kind != SEMAPHORE:
+            return super().__enter__()
         return get_hub().threadpool.apply(super().__enter__)
 
+
+try:
+    os.eventfd
+    SemLock = SemLockEventFd
+except AttributeError:
+    SemLock = SemLockSem
 
 Semaphore = type("Semaphore", (SemLock,), dict(_Semaphore.__dict__))
 BoundedSemaphore = type("BoundedSemaphore", (Semaphore,), dict(_BoundedSemaphore.__dict__))


### PR DESCRIPTION
Otherwise SemLock is semaphore-based and blocks when RLock

eventfd-based solution doesn't work with `forkserver`

fixes #16