### PR TITLE
Add release app token for branch protection bypass

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,8 @@ jobs:
             && contains(env.DEPLOY_OSES, runner.os)
             && contains(env.DEPLOY_PYTHONS, matrix.python-version) }}
           with-venv: ${{ matrix.with-venv }}
+          release-app-id: ${{ secrets.PYBUILDER_RELEASE_APP_ID }}
+          release-app-private-key: ${{ secrets.PYBUILDER_RELEASE_APP_PRIVATE_KEY }}
   build-summary:
     if: success() || failure()
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pass pybuilder-release GitHub App credentials to pybuilder/build action for bypassing branch protection during release automation.